### PR TITLE
Update format of gpg-agent.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ echo >~/.gnupg/gpg-agent.conf <<HERE
 default-cache-ttl 600
 max-cache-ttl 999999
 enable-ssh-support
-pinentry-program=GITPATH/pinentry-mac/build/Release/pinentry-mac.app/Contents/MacOS/pinentry-mac
+pinentry-program GITPATH/pinentry-mac/build/Release/pinentry-mac.app/Contents/MacOS/pinentry-mac
 HERE
 ```
 


### PR DESCRIPTION
The `=` causes gpg-agent to report `gpg-agent[79259]: /Users/davidjb/.gnupg/gpg-agent.conf:4: invalid option`.  Removing this corrects the format of the file.  I'm using GPG agent v2.0.30 if other versions happen to require a different format.